### PR TITLE
Revert "Bump tensorflow from 1.15.2 to 2.3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.15.1
-tensorflow==2.3.1
+tensorflow==1.15.2
 scikit_learn==0.20.1


### PR DESCRIPTION
I merged this without looking properly, reverting as it bumps TF to a back-incompatible version and there's no new work on this project

Reverts BritishGeologicalSurvey/tweet_classification#3